### PR TITLE
足の衝突判定の許容誤差の設定をミスって地面を左右移動できなくなっていた

### DIFF
--- a/src/core/entities/playerFactory.ts
+++ b/src/core/entities/playerFactory.ts
@@ -61,7 +61,7 @@ export class PlayerFactory extends EntityFactory {
     aabbFoot.tag = 'foot'
     aabbFoot.category = Category.PLAYER
     aabbFoot.mask = Category.WALL
-    aabbBody.maxClipTolerance = new Vec2(
+    aabbFoot.maxClipTolerance = new Vec2(
       this.FOOT_CLIP_TOLERANCE_X,
       this.FOOT_CLIP_TOLERANCE_Y
     )


### PR DESCRIPTION
AABBの衝突判定をする際、x軸y軸共に浅かったら当たっていない判定にするようにしていたが、それに使う定数の設定を間違えていた